### PR TITLE
namespace bin update command

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "tape test/*.js"
   },
   "bin": {
-    "update": "bin/update.js"
+    "price-pigeon-update": "bin/update.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/price-pigeon",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Fetch AWS OnDemand prices for easy import into other modules",
   "main": "priceMapper.js",
   "scripts": {


### PR DESCRIPTION
This causes installation problems if there's another module with a bin command titled `update`. This PR moves the command to the namespaced `price-pigeon-update` so we don't risk collision 💥 