### PR TITLE
update prices

### DIFF
--- a/priceMap.json
+++ b/priceMap.json
@@ -1,15 +1,6 @@
 {
-  "g2.8xlarge": {
-    "price": 3.592
-  },
-  "c3.xlarge": {
-    "price": 0.292
-  },
   "c4.8xlarge": {
-    "price": 2.195
-  },
-  "cr1.8xlarge": {
-    "price": 3.75
+    "price": 2.085
   },
   "r3.large": {
     "price": 0.219
@@ -17,26 +8,32 @@
   "m2.2xlarge": {
     "price": 0.651
   },
-  "x1.32xlarge": {
-    "price": 19.341
+  "m4.16xlarge": {
+    "price": 4.305
   },
   "r3.2xlarge": {
     "price": 0.878
   },
+  "g2.8xlarge": {
+    "price": 3.592
+  },
   "m1.xlarge": {
     "price": 0.514
   },
-  "m4.xlarge": {
-    "price": 0.37
+  "i3.xlarge": {
+    "price": 0.411
+  },
+  "r4.xlarge": {
+    "price": 0.351
+  },
+  "p2.8xlarge": {
+    "price": 8.554
   },
   "m3.2xlarge": {
     "price": 0.82
   },
-  "t2.medium": {
-    "price": 0.08
-  },
   "c4.xlarge": {
-    "price": 0.302
+    "price": 0.287
   },
   "c3.large": {
     "price": 0.145
@@ -44,20 +41,14 @@
   "m2.4xlarge": {
     "price": 1.301
   },
-  "m3.xlarge": {
-    "price": 0.409
-  },
-  "m2.xlarge": {
-    "price": 0.326
-  },
   "cc2.8xlarge": {
     "price": 2.25
   },
-  "t2.large": {
-    "price": 0.16
+  "r4.16xlarge": {
+    "price": 5.1072
   },
   "t2.nano": {
-    "price": 0.01
+    "price": 0.008
   },
   "d2.xlarge": {
     "price": 0.957
@@ -65,26 +56,23 @@
   "i2.8xlarge": {
     "price": 8.14
   },
-  "c4.large": {
-    "price": 0.15
+  "p2.16xlarge": {
+    "price": 15.552
   },
-  "m3.medium": {
-    "price": 0.102
+  "c4.large": {
+    "price": 0.143
+  },
+  "i3.large": {
+    "price": 0.206
   },
   "c4.4xlarge": {
-    "price": 1.207
-  },
-  "m4.4xlarge": {
-    "price": 1.48
+    "price": 1.146
   },
   "d2.4xlarge": {
     "price": 3.828
   },
-  "r3.xlarge": {
-    "price": 0.439
-  },
-  "c3.4xlarge": {
-    "price": 1.164
+  "c3.xlarge": {
+    "price": 0.292
   },
   "i2.xlarge": {
     "price": 1.12
@@ -92,14 +80,14 @@
   "c3.2xlarge": {
     "price": 0.582
   },
-  "t2.small": {
-    "price": 0.04
+  "m2.xlarge": {
+    "price": 0.326
   },
   "m1.large": {
     "price": 0.256
   },
-  "m4.large": {
-    "price": 0.185
+  "r4.8xlarge": {
+    "price": 2.809
   },
   "t1.micro": {
     "price": 0.025
@@ -110,41 +98,65 @@
   "c1.xlarge": {
     "price": 0.721
   },
-  "m4.10xlarge": {
-    "price": 3.363
-  },
   "c4.2xlarge": {
-    "price": 0.604
+    "price": 0.574
   },
   "m1.small": {
     "price": 0.064
   },
+  "x1.32xlarge": {
+    "price": 19.341
+  },
   "d2.8xlarge": {
     "price": 6.96
   },
-  "m1.medium": {
-    "price": 0.129
+  "i3.2xlarge": {
+    "price": 0.823
   },
-  "m3.large": {
-    "price": 0.205
+  "m4.xlarge": {
+    "price": 0.296
+  },
+  "t2.large": {
+    "price": 0.128
   },
   "i2.2xlarge": {
     "price": 2.239
   },
-  "hs1.8xlarge": {
-    "price": 5.57
+  "c3.4xlarge": {
+    "price": 1.164
+  },
+  "m4.large": {
+    "price": 0.147
+  },
+  "m4.4xlarge": {
+    "price": 1.184
+  },
+  "cr1.8xlarge": {
+    "price": 3.75
   },
   "i2.4xlarge": {
     "price": 4.477
+  },
+  "i3.4xlarge": {
+    "price": 1.646
   },
   "c1.medium": {
     "price": 0.18
   },
   "m4.2xlarge": {
-    "price": 0.74
+    "price": 0.592
   },
-  "d2.2xlarge": {
-    "price": 1.914
+  "r4.2xlarge": {
+    "price": 0.702
+  },
+  "m3.xlarge": {
+    "price": 0.409
+  },
+  "m1.medium": {
+    "price": 0.129
+  },
+  "i3.8xlarge": {
+    "price": 3.291
   },
   "hi1.4xlarge": {
     "price": 3.1
@@ -152,16 +164,61 @@
   "c3.8xlarge": {
     "price": 2.117
   },
-  "r3.4xlarge": {
-    "price": 1.756
+  "r4.4xlarge": {
+    "price": 1.404
+  },
+  "t2.small": {
+    "price": 0.032
+  },
+  "i3.16xlarge": {
+    "price": 5.984
+  },
+  "x1.16xlarge": {
+    "price": 10.638
+  },
+  "t2.medium": {
+    "price": 0.064
+  },
+  "t2.xlarge": {
+    "price": 0.256
+  },
+  "d2.2xlarge": {
+    "price": 1.914
+  },
+  "r3.xlarge": {
+    "price": 0.439
+  },
+  "m3.medium": {
+    "price": 0.102
+  },
+  "r4.large": {
+    "price": 0.176
+  },
+  "m3.large": {
+    "price": 0.205
   },
   "t2.micro": {
-    "price": 0.02
+    "price": 0.016
+  },
+  "r3.4xlarge": {
+    "price": 1.756
   },
   "g2.2xlarge": {
     "price": 0.988
   },
+  "hs1.8xlarge": {
+    "price": 5.57
+  },
+  "p2.xlarge": {
+    "price": 1.069
+  },
+  "m4.10xlarge": {
+    "price": 2.69
+  },
   "cg1.4xlarge": {
     "price": 2.36
+  },
+  "t2.2xlarge": {
+    "price": 0.512
   }
 }

--- a/test/priceMapper.tape.js
+++ b/test/priceMapper.tape.js
@@ -6,7 +6,7 @@ var tape = require('tape');
 
 tape('priceMapper', function(assert) {
     var ratio = 0.25;
-    var fullPrice = 0.08;
+    var fullPrice = 0.064;
 
     var ratioPriceMap = priceMapper(ratio);
     var ratioPrice = ratioPriceMap['t2.medium']['price'];
@@ -37,6 +37,6 @@ tape('calculatePrice', function(assert) {
 
     var actualHalfMap = lib.calculatePrice(originalMap, halfRatio);
     assert.deepEqual(actualHalfMap, expectedHalfMap, 'calculatePrice changes prices correctly');
-    
+
     assert.end();
 });


### PR DESCRIPTION
re-ran `bin/update.js` to get the latest pricing. Adds missing r4 instances and other new instance types (p2, i3, x1...)

cc/ @emilymcafee @xrwang @emilymdubois @KaiBot3000

